### PR TITLE
ログアウト時のリンクの修正

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,10 +1,10 @@
 <header class='navbar navbar-expand-lg'>
 
-
-<%= link_to  image_tag("Logo.jpeg"), root_path, class: 'nav-link'  %>
-
-
-
+<% if user_signed_in? %>
+  <%= link_to  image_tag("Logo.jpeg"), root_path, class: 'nav-link'  %>
+<% else %>
+  <%= link_to  image_tag("Logo.jpeg"), about_path, class: 'nav-link'  %>
+<% end %>
 
 
   <button class='navbar-toggler' type='button' id="toggler-icon" data-toggle='collapse' data-target='#navbarTogglerDemo01' aria-controls='navbarTogglerDemo01' aria-expanded='false' aria-label='Toggle navigation'>


### PR DESCRIPTION
ロゴをクリックすると、ログアウトしているときは「トレコミアプリ」に、ログインしているときは「メイン」に飛ぶようにしました。
確認お願いします。